### PR TITLE
add jvmLaunchers

### DIFF
--- a/src/main/java/org/apache/commons/exec/jvm/Consumer.java
+++ b/src/main/java/org/apache/commons/exec/jvm/Consumer.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+/**
+ * Instead of java8 java.util.function.Consumer
+ * */
+public interface Consumer<T>
+{
+    void accept(T t);
+}

--- a/src/main/java/org/apache/commons/exec/jvm/JVMException.java
+++ b/src/main/java/org/apache/commons/exec/jvm/JVMException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+public class JVMException
+        extends Exception
+{
+    private static final long serialVersionUID = -1L;
+
+    public JVMException(String message)
+    {
+        super(message);
+    }
+
+    public JVMException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/apache/commons/exec/jvm/JVMLauncher.java
+++ b/src/main/java/org/apache/commons/exec/jvm/JVMLauncher.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class JVMLauncher<R extends Serializable>
+{
+    private final VmCallable<R> callable;
+    private final Collection<URL> userJars;
+    private final Consumer<String> consoleHandler;
+    private final boolean depThisJvm;
+    private final List<String> otherVmOps;
+
+    private Process process;
+
+    JVMLauncher(
+            VmCallable<R> callable,
+            Consumer<String> consoleHandler,
+            Collection<URL> userJars,
+            boolean depThisJvm,
+            List<String> otherVmOps)
+    {
+        this.callable = callable;
+        this.userJars = userJars;
+        this.consoleHandler = consoleHandler;
+        this.depThisJvm = depThisJvm;
+        this.otherVmOps = otherVmOps;
+    }
+
+    public VmFuture<R> startAndGet()
+            throws IOException, ClassNotFoundException, JVMException
+    {
+        return startAndGet(null);
+    }
+
+    public VmFuture<R> startAndGet(ClassLoader classLoader)
+            throws IOException, ClassNotFoundException, JVMException
+    {
+        Socket socketClient = null;
+        InputStream inputStream = null;
+        try {
+            socketClient = startAndGetByte();
+            inputStream = socketClient.getInputStream();
+
+            VmFuture<R> vmFuture = (VmFuture<R>) Serializables.byteToObject(inputStream);
+            if (vmFuture.get() == null) {
+                throw new JVMException(vmFuture.getOnFailure());
+            }
+            return vmFuture;
+        }
+        finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+            if (socketClient != null) {
+                socketClient.close();
+            }
+        }
+    }
+
+    /**
+     * send obj callable to execJvm
+     */
+    private Socket startAndGetByte()
+            throws IOException, JVMException
+    {
+        ServerSocket sock = null;
+        try {
+            sock = new ServerSocket();
+            sock.bind(new InetSocketAddress(InetAddress.getLocalHost(), 0));
+            ProcessBuilder builder = new ProcessBuilder(buildMainArg(sock.getLocalPort(), otherVmOps))
+                    .redirectErrorStream(true);
+
+            this.process = builder.start();
+            OutputStream os = null;
+            try {
+                os = new BufferedOutputStream(process.getOutputStream());
+                os.write(Serializables.serialize(callable));
+            }
+            finally {
+                if (os != null) {
+                    os.close();
+                }
+            }
+
+            BufferedReader reader = null;
+            try {
+                reader = new BufferedReader(new InputStreamReader(process.getInputStream(), "utf-8"));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    consoleHandler.accept(line);
+                }
+            }
+            finally {
+                if (reader != null) {
+                    reader.close();
+                }
+            }
+            //---return Socket io Stream
+            // If you execute here and jump out of the above where the child process has exited
+            // Set a maximum of 3 seconds to wait to prevent the child process from exiting unexpectedly
+            // Under normal circumstances, when the child process exits, it has already written back the data. Here, you need to set the abnormal exit time. Maximum waiting time.
+            sock.setSoTimeout(3000);
+            try {
+                return sock.accept();
+            }
+            catch (SocketTimeoutException e) {
+                //todo: if isAlive
+//                if (process.isAlive()) {
+//                    process.destroy();
+//                }
+                throw new JVMException("Jvm child process abnormal exit, exit code " + process.exitValue(), e);
+            }
+        }
+        finally {
+            if (sock != null) {
+                sock.close();
+            }
+        }
+    }
+
+    private String getUserAddClasspath()
+    {
+        StringBuilder builder = new StringBuilder();
+        for (URL url : userJars) {
+            builder.append(File.pathSeparator).append(url.getPath());
+        }
+        return builder.length() == 0 ? "" : builder.substring(File.pathSeparator.length());
+    }
+
+    private List<String> buildMainArg(int port, List<String> otherVmOps)
+    {
+        File java = new File(new File(System.getProperty("java.home"), "bin"), "java");
+        List<String> ops = new ArrayList<String>();
+        ops.add(java.toString());
+
+        ops.addAll(otherVmOps);
+
+        ops.add("-classpath");
+
+        String userSdkJars = getUserAddClasspath(); //Add additional jar dependencies for users
+        if (depThisJvm) {
+            ops.add(System.getProperty("java.class.path") + ":" + userSdkJars);
+        }
+        else {
+            ops.add(userSdkJars);
+        }
+
+        String javaLibPath = System.getProperty("java.library.path");
+        if (javaLibPath != null) {
+            ops.add("-Djava.library.path=" + javaLibPath);
+        }
+        ops.add(JVMLauncher.class.getCanonicalName()); //Child process Main.class
+        ops.add(Integer.toString(port));
+        return ops;
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        System.out.println("vm start ok ...");
+        VmFuture<? extends Serializable> future;
+
+        ObjectInputStream ois = null;
+        try {
+            ois = new ObjectInputStream(System.in);
+            System.out.println("vm start init ok ...");
+            VmCallable<? extends Serializable> callable = (VmCallable<? extends Serializable>) ois.readObject();
+            future = new VmFuture<Serializable>(callable.call());
+        }
+        catch (Throwable e) {
+            future = new VmFuture<Serializable>(getStackTraceAsString(e));
+        }
+        finally {
+            if (ois != null) {
+                ois.close();
+            }
+        }
+
+        OutputStream out = null;
+        try {
+            out = chooseOutputStream(args);
+            out.write(Serializables.serialize(future));
+            System.out.println("vm exiting ok ...");
+        }
+        finally {
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+
+    /**
+     * Read the port passed in args, communicate with the parent process, report the result
+     */
+    private static OutputStream chooseOutputStream(String[] args)
+            throws IOException
+    {
+        if (args.length > 0) {
+            int port = Integer.parseInt(args[0]);
+            Socket sock = new Socket();
+            sock.connect(new InetSocketAddress(InetAddress.getLocalHost(), port));
+            return sock.getOutputStream();
+        }
+        else {
+            return System.out;
+        }
+    }
+
+    /**
+     * Returns a string containing the result of {@link Throwable#toString() toString()}
+     */
+    private static String getStackTraceAsString(Throwable throwable)
+    {
+        StringWriter stringWriter = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
+}

--- a/src/main/java/org/apache/commons/exec/jvm/JVMLaunchers.java
+++ b/src/main/java/org/apache/commons/exec/jvm/JVMLaunchers.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import java.io.Serializable;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * JVMLauncher builder
+ */
+public class JVMLaunchers
+{
+    private JVMLaunchers() {}
+
+    public static class VmBuilder<T extends Serializable>
+    {
+        private VmCallable<T> callable;
+        private boolean depThisJvm = true;
+        private Consumer<String> consoleHandler;
+        private final List<URL> tmpJars = new ArrayList<URL>();
+        private final List<String> otherVmOps = new ArrayList<String>();
+
+        public VmBuilder<T> setCallable(VmCallable<T> callable)
+        {
+            this.callable = requireNonNull(callable, "callable is null");
+            return this;
+        }
+
+        public VmBuilder<T> setConsole(Consumer<String> consoleHandler)
+        {
+            this.consoleHandler = requireNonNull(consoleHandler, "consoleHandler is null");
+            return this;
+        }
+
+        /**
+         * Do not rely on the dependency of the current classloader of any sub-process.
+         * Please use this option carefully. {@link java.lang.ClassNotFoundException} may occur.
+         */
+        public VmBuilder<T> notDepThisJvmClassPath()
+        {
+            depThisJvm = false;
+            return this;
+        }
+
+        public VmBuilder<T> addUserURLClassLoader(URLClassLoader vmClassLoader)
+        {
+            ClassLoader classLoader = vmClassLoader;
+            while (classLoader instanceof URLClassLoader) {
+                Collections.addAll(tmpJars, ((URLClassLoader) classLoader).getURLs());
+                classLoader = classLoader.getParent();
+            }
+            return this;
+        }
+
+        public VmBuilder<T> addUserjars(Collection<URL> jars)
+        {
+            tmpJars.addAll(jars);
+            return this;
+        }
+
+        public VmBuilder<T> setXms(String xms)
+        {
+            otherVmOps.add("-Xms" + xms);
+            return this;
+        }
+
+        public VmBuilder<T> setXmx(String xmx)
+        {
+            otherVmOps.add("-Xmx" + xmx);
+            return this;
+        }
+
+        public JVMLauncher<T> build()
+        {
+            requireNonNull(consoleHandler, "setConsole(Consumer<String> consoleHandler) not setting");
+            requireNonNull(callable, "callable not setting");
+            return new JVMLauncher<T>(callable, consoleHandler, tmpJars, depThisJvm, otherVmOps);
+        }
+    }
+
+    public static <T extends Serializable> VmBuilder<T> newJvm()
+    {
+        return new VmBuilder<T>();
+    }
+
+    private static <V> V requireNonNull(V obj, String message)
+    {
+        if (obj == null) {
+            throw new NullPointerException(message);
+        }
+        return obj;
+    }
+}

--- a/src/main/java/org/apache/commons/exec/jvm/Serializables.java
+++ b/src/main/java/org/apache/commons/exec/jvm/Serializables.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+/**
+ * Serialization tool class
+ */
+public class Serializables
+{
+    private Serializables() {}
+
+    public static byte[] serialize(Serializable serializable)
+            throws IOException
+    {
+        ByteArrayOutputStream bos = null;
+        ObjectOutputStream os = null;
+        try {
+            bos = new ByteArrayOutputStream();
+            os = new ObjectOutputStream(bos);
+
+            os.writeObject(serializable);
+            return bos.toByteArray();
+        }
+        finally {
+            if (bos != null) {
+                bos.close();
+            }
+            if (os != null) {
+                os.close();
+            }
+        }
+    }
+
+    public static Object byteToObject(InputStream inputStream)
+            throws IOException, ClassNotFoundException
+    {
+        ObjectInputStream oi = null;
+        try {
+            oi = new ObjectInputStream(inputStream);
+            return oi.readObject();
+        }
+        finally {
+            if (oi != null) {
+                oi.close();
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/exec/jvm/VmCallable.java
+++ b/src/main/java/org/apache/commons/exec/jvm/VmCallable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+/**
+ * The parent process passes the Callable task to the child process execution,
+ * which is reflected as a function transfer on java8.
+ */
+public interface VmCallable<V extends Serializable>
+        extends Callable<V>, Serializable
+{
+}

--- a/src/main/java/org/apache/commons/exec/jvm/VmFuture.java
+++ b/src/main/java/org/apache/commons/exec/jvm/VmFuture.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import java.io.Serializable;
+
+/**
+ * Child process reports data using VmFuture
+ * */
+public class VmFuture<V extends Serializable>
+        implements Serializable
+{
+    private V result;
+    private String errorMessage;
+
+    public V get()
+    {
+        return result;
+    }
+
+    public String getOnFailure()
+    {
+        return errorMessage;
+    }
+
+    public VmFuture(Serializable result)
+    {
+        this.result = (V) result;
+    }
+
+    public VmFuture(String errorMessage)
+    {
+        this.errorMessage = errorMessage;
+    }
+
+    public VmFuture(Serializable result, String errorMessage)
+    {
+        this.errorMessage = errorMessage;
+    }
+
+    static <V extends Serializable> VmFuture<V> make(Serializable result, String errorMessage)
+    {
+        return new VmFuture<V>(result, errorMessage);
+    }
+}

--- a/src/test/java/org/apache/commons/exec/jvm/JVMLaunchersTest.java
+++ b/src/test/java/org/apache/commons/exec/jvm/JVMLaunchersTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.commons.exec.jvm;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+public class JVMLaunchersTest
+{
+
+    @Test
+    public void newJvm()
+            throws Exception
+    {
+        int exitCode = testNewJvm();
+        Assert.assertEquals(exitCode, 1);
+    }
+
+    private static int testNewJvm()
+            throws JVMException, IOException, ClassNotFoundException
+    {
+        JVMLauncher<Integer> launcher = JVMLaunchers.<Integer>newJvm()
+                .setCallable(new VmCallable<Integer>()
+                {
+                    @Override
+                    public Integer call()
+                            throws Exception
+                    {
+                        System.out.println("************ Compile start ***************");
+                        TimeUnit.SECONDS.sleep(1);
+                        System.out.println("************ Compile stop ***************");
+                        return 1;
+                    }
+                })
+                .addUserjars(Collections.<URL>emptyList())
+                .setConsole(new Consumer<String>()
+                {
+                    @Override
+                    public void accept(String msg)
+                    {
+                        System.out.println(msg);
+                    }
+                })
+                .setXms("16m")
+                .setXmx("16m")
+                .build();
+        VmFuture<Integer> out = launcher.startAndGet();
+        return out.get();
+    }
+}


### PR DESCRIPTION
When you need to perform some operations through a child process, it is very cumbersome and requires a lot of coding. I have an api below to simplify this process and make it elegant

Like this: The Callable event is executed by the child process (jvm)
```
        JVMLauncher<Integer> launcher = JVMLaunchers.<Integer>newJvm()
                .setCallable(() -> {
                    System.out.println("************ Compile start ***************");
                    TimeUnit.SECONDS.sleep(1);
                    System.out.println("************ Compile stop ***************");
                    return 1;
                })
                .setXms("16m")
                .setXmx("16m")
                .addUserjars(Collections.emptyList())
                .setConsole((msg) -> System.err.println(msg))
                .build();

        VmFuture<Integer> out = launcher.startAndGet();
```