### PR TITLE
Update commons-parent to 48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-parent</artifactId>
-        <version>38</version>
+        <version>48</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Apache Commons Exec</name>


### PR DESCRIPTION
This allows compilation with up-to-date OpenJDK 8 and 11 (see https://www.travis-ci.org/krichter722/commons-exec/builds/527044757 for details - I'll provide these changes as a follow-up).