### PR TITLE
EXEC-112

### DIFF
--- a/src/main/java/org/apache/commons/exec/LogOutputStream.java
+++ b/src/main/java/org/apache/commons/exec/LogOutputStream.java
@@ -181,8 +181,8 @@ public abstract class LogOutputStream
             } catch (UnsupportedEncodingException e) {
                 throw new IllegalStateException(e);
             }
-            buffer.reset();
         }
+        buffer.reset();
     }
 
     /**

--- a/src/main/java/org/apache/commons/exec/LogOutputStream.java
+++ b/src/main/java/org/apache/commons/exec/LogOutputStream.java
@@ -21,6 +21,8 @@ package org.apache.commons.exec;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 
 /**
  * Base class to connect a logging system to the output and/or
@@ -49,6 +51,8 @@ public abstract class LogOutputStream
 
     private final int level;
 
+    private final Charset charset;
+
     /**
      * Creates a new instance of this class.
      * Uses the default level of 999.
@@ -63,7 +67,19 @@ public abstract class LogOutputStream
      * @param level loglevel used to log data written to this stream.
      */
     public LogOutputStream(final int level) {
+        this(level, null);
+    }
+
+    /**
+     * Creates a new instance of this class, specifying the character set that should be used for
+     * outputting the string for each line
+     *
+     * @param level loglevel used to log data written to this stream
+     * @param charset Character Set to use when processing lines
+     */
+    public LogOutputStream(final int level, final Charset charset) {
         this.level = level;
+        this.charset = charset;
     }
 
     /**
@@ -157,8 +173,16 @@ public abstract class LogOutputStream
      * Converts the buffer to a string and sends it to {@code processLine}.
      */
     protected void processBuffer() {
-        processLine(buffer.toString());
-        buffer.reset();
+        if (charset == null) {
+            processLine(buffer.toString());
+        } else {
+            try {
+                processLine(buffer.toString(charset.name()));
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalStateException(e);
+            }
+            buffer.reset();
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/exec/LogOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/exec/LogOutputStreamTest.java
@@ -85,17 +85,6 @@ public class LogOutputStreamTest {
         assertEquals("This string contains UTF-8 characters like the see no evil monkey \uD83D\uDE48 and the right single quotation mark \u2019", ((SystemLogOutputStream) systemOut).getOutput());
     }
 
-    @Test
-    public void testStdoutWithUTF8CharactersAndNoCharsetSpecified() throws Exception {
-        this.systemOut = new SystemLogOutputStream(1);
-        this.exec.setStreamHandler(new PumpStreamHandler(systemOut, systemOut));
-
-        final CommandLine cl = new CommandLine(utf8CharacterScript);
-        final int exitValue = exec.execute(cl);
-        assertFalse(exec.isFailure(exitValue));
-        assertEquals("This string contains UTF-8 characters like the see no evil monkey \uD83D\uDE48 and the right single quotation mark \u2019", ((SystemLogOutputStream) systemOut).getOutput());
-    }
-
     // ======================================================================
     // Helper classes
     // ======================================================================

--- a/src/test/scripts/utf8Characters.bat
+++ b/src/test/scripts/utf8Characters.bat
@@ -1,0 +1,22 @@
+@ECHO OFF
+
+REM
+REM Licensed to the Apache Software Foundation (ASF) under one or more
+REM contributor license agreements.  See the NOTICE file distributed with
+REM this work for additional information regarding copyright ownership.
+REM The ASF licenses this file to You under the Apache License, Version 2.0
+REM (the "License"); you may not use this file except in compliance with
+REM the License.  You may obtain a copy of the License at
+REM
+REM      http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+REM
+REM
+
+REM echo some UTF-8 extended characters
+ECHO This string contains UTF-8 characters like the see no evil monkey 🙈 and the right single quotation mark ’

--- a/src/test/scripts/utf8Characters.sh
+++ b/src/test/scripts/utf8Characters.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+# echo some UTF-8 extended characters
+echo "This string contains UTF-8 characters like the see no evil monkey 🙈 and the right single quotation mark ’"


### PR DESCRIPTION
This PR addresses EXEC-112 by adding a "charset" variable to the LogOutputStream class, and providing an overloaded constructor to allow a user to set it. If this is set, when calling processBuffer, the buffer.toString calls uses the overload with a charset name specified. Existing behaviour with the original constructor is maintained.

The first commit adds a unit test that fails when running "mvn verify" from the command line on Windows so that the issue can be verified, this test is removed in a subsequent commit.