### PR TITLE
fix travis-ci scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,17 @@
 
 language: java
 sudo: true
-
+dist: trusty
 # Required to build with openjdk6 and 7
-dist: precise
 cache:
   directories:
     - $HOME/.m2
-jdk:
-  - openjdk6
-  - openjdk7
-  - openjdk8
-  - openjdk11
-
+matrix:
+  include:
+    - dist: precise
+      jdk: openjdk6
+    - jdk: openjdk7
+    - jdk: openjdk8
+    - jdk: openjdk11
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@
 
 language: java
 sudo: true
-dist: trusty
 # Required to build with openjdk6 and 7
+dist: trusty
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ language: java
 sudo: true
 
 # Required to build with openjdk6 and 7
-dist: trusty
+dist: precise
 cache:
   directories:
     - $HOME/.m2
 jdk:
+  - openjdk6
   - openjdk7
   - openjdk8
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,10 @@ sudo: true
 
 # Required to build with openjdk6 and 7
 dist: trusty
-
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
+cache:
+  directories:
+    - $HOME/.m2
 jdk:
-  - openjdk6
   - openjdk7
   - openjdk8
   - openjdk11


### PR DESCRIPTION
Hi.
I saw through your travis-ci scripts.
Yes the `addons:` worked several years ago but now it not working anymore.
I found no way for creating ci on travis-ci for jdk6.
So, if you have any ideas about how to make it, I'm rather happy to learn about it.
Otherwise we might have to delete jdk6 in travis scripts.