### PR TITLE
delete some unnecessary code, fix some wrong spelling in comment

### DIFF
--- a/src/main/java/org/apache/commons/exec/CommandLine.java
+++ b/src/main/java/org/apache/commons/exec/CommandLine.java
@@ -345,7 +345,7 @@ public class CommandLine {
         final int inQuote = 1;
         final int inDoubleQuote = 2;
         int state = normal;
-        final StringTokenizer tok = new StringTokenizer(toProcess, "\"\' ", true);
+        final StringTokenizer tok = new StringTokenizer(toProcess, "\"' ", true);
         final ArrayList<String> list = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean lastTokenHasBeenQuoted = false;
@@ -354,7 +354,7 @@ public class CommandLine {
             final String nextTok = tok.nextToken();
             switch (state) {
             case inQuote:
-                if ("\'".equals(nextTok)) {
+                if ("'".equals(nextTok)) {
                     lastTokenHasBeenQuoted = true;
                     state = normal;
                 } else {
@@ -370,7 +370,7 @@ public class CommandLine {
                 }
                 break;
             default:
-                if ("\'".equals(nextTok)) {
+                if ("'".equals(nextTok)) {
                     state = inQuote;
                 } else if ("\"".equals(nextTok)) {
                     state = inDoubleQuote;

--- a/src/main/java/org/apache/commons/exec/DefaultExecutor.java
+++ b/src/main/java/org/apache/commons/exec/DefaultExecutor.java
@@ -233,7 +233,7 @@ public class DefaultExecutor implements Executor {
     /** @see org.apache.commons.exec.Executor#setExitValues(int[]) */
     @Override
     public void setExitValues(final int[] values) {
-        this.exitValues = values == null ? null : (int[]) values.clone();
+        this.exitValues = values == null ? null : values.clone();
     }
 
     /** @see org.apache.commons.exec.Executor#isFailure(int) */

--- a/src/main/java/org/apache/commons/exec/OS.java
+++ b/src/main/java/org/apache/commons/exec/OS.java
@@ -247,7 +247,7 @@ public final class OS {
                     isFamily = OS_NAME.contains(FAMILY_VMS);
                 } else {
                     throw new RuntimeException(
-                            "Don\'t know how to detect os family \""
+                            "Don't know how to detect os family \""
                                     + family + "\"");
                 }
             }

--- a/src/main/java/org/apache/commons/exec/PumpStreamHandler.java
+++ b/src/main/java/org/apache/commons/exec/PumpStreamHandler.java
@@ -256,7 +256,7 @@ public class PumpStreamHandler implements ExecuteStreamHandler {
      * @return the stream pumper thread
      */
     protected Thread createPump(final InputStream is, final OutputStream os) {
-        final boolean closeWhenExhausted = os instanceof PipedOutputStream ? true : false;
+        final boolean closeWhenExhausted = os instanceof PipedOutputStream;
         return createPump(is, os, closeWhenExhausted);
     }
 

--- a/src/main/java/org/apache/commons/exec/Watchdog.java
+++ b/src/main/java/org/apache/commons/exec/Watchdog.java
@@ -80,6 +80,7 @@ public class Watchdog implements Runnable {
                 try {
                     wait(timeLeft);
                 } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
                 timeLeft = timeout - (System.currentTimeMillis() - startTime);
                 isWaiting = timeLeft > 0;

--- a/src/main/java/org/apache/commons/exec/environment/DefaultProcessingEnvironment.java
+++ b/src/main/java/org/apache/commons/exec/environment/DefaultProcessingEnvironment.java
@@ -216,7 +216,7 @@ public class DefaultProcessingEnvironment {
      */
     private Map<String, String> createEnvironmentMap() {
         if (OS.isFamilyWindows()) {
-            return new TreeMap<>(new Comparator<>() {
+            return new TreeMap<>(new Comparator<String>() {
                 @Override
                 public int compare(final String key0, final String key1) {
                     return key0.compareToIgnoreCase(key1);

--- a/src/main/java/org/apache/commons/exec/environment/DefaultProcessingEnvironment.java
+++ b/src/main/java/org/apache/commons/exec/environment/DefaultProcessingEnvironment.java
@@ -56,8 +56,8 @@ public class DefaultProcessingEnvironment {
         }
 
         // create a copy of the map just in case that
-        // anyone is going to modifiy it, e.g. removing
-        // or setting an evironment variable
+        // anyone is going to modify it, e.g. removing
+        // or setting an environment variable
         final Map<String, String> copy = createEnvironmentMap();
         copy.putAll(procEnvironment);
         return copy;
@@ -216,7 +216,7 @@ public class DefaultProcessingEnvironment {
      */
     private Map<String, String> createEnvironmentMap() {
         if (OS.isFamilyWindows()) {
-            return new TreeMap<>(new Comparator<String>() {
+            return new TreeMap<>(new Comparator<>() {
                 @Override
                 public int compare(final String key0, final String key1) {
                     return key0.compareToIgnoreCase(key1);

--- a/src/main/java/org/apache/commons/exec/environment/EnvironmentUtils.java
+++ b/src/main/java/org/apache/commons/exec/environment/EnvironmentUtils.java
@@ -62,8 +62,8 @@ public class EnvironmentUtils
         final String[] result = new String[environment.size()];
         int i = 0;
         for (final Entry<String, String> entry : environment.entrySet()) {
-            final String key  = entry.getKey() == null ? "" : entry.getKey().toString();
-            final String value = entry.getValue() == null ? "" : entry.getValue().toString();
+            final String key  = entry.getKey() == null ? "" : entry.getKey();
+            final String value = entry.getValue() == null ? "" : entry.getValue();
             result[i] = key + "=" + value;
             i++;
         }

--- a/src/main/java/org/apache/commons/exec/util/DebugUtils.java
+++ b/src/main/java/org/apache/commons/exec/util/DebugUtils.java
@@ -26,7 +26,7 @@ public class DebugUtils
 {
     /**
      * System property to determine how to handle exceptions. When
-     * set to "false" we rethrow the otherwise silently catched
+     * set to "false" we rethrow the otherwise silently caught
      * exceptions found in the original code. The default value
      * is "true"
      */

--- a/src/main/java/org/apache/commons/exec/util/MapUtils.java
+++ b/src/main/java/org/apache/commons/exec/util/MapUtils.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Helper classes to manipulate maps to pass substition map to the CommandLine. This class is not part of the public API
+ * Helper classes to manipulate maps to pass substitution map to the CommandLine. This class is not part of the public API
  * and could change without warning.
  *
  */

--- a/src/main/java/org/apache/commons/exec/util/StringUtils.java
+++ b/src/main/java/org/apache/commons/exec/util/StringUtils.java
@@ -35,7 +35,7 @@ import java.util.StringTokenizer;
  */
 public class StringUtils {
 
-    private static final String SINGLE_QUOTE = "\'";
+    private static final String SINGLE_QUOTE = "'";
     private static final String DOUBLE_QUOTE = "\"";
     private static final char SLASH_CHAR = '/';
     private static final char BACKSLASH_CHAR = '\\';
@@ -113,7 +113,7 @@ public class StringUtils {
                                 value = fixFileSeparatorChar(((File) temp).getAbsolutePath());
                             }
                             else {
-                                value = temp != null ? temp.toString() : null;    
+                                value = temp != null ? temp.toString() : null;
                             }
 
                             if (value != null) {
@@ -168,7 +168,7 @@ public class StringUtils {
         while (tokens.hasMoreTokens()) {
             strList.add(tokens.nextToken());
         }
-        return strList.toArray(new String[strList.size()]);
+        return strList.toArray(new String[0]);
     }
 
     /**
@@ -232,15 +232,15 @@ public class StringUtils {
         }
 
         final StringBuilder buf = new StringBuilder();
-        if (cleanedArgument.indexOf(DOUBLE_QUOTE) > -1) {
-            if (cleanedArgument.indexOf(SINGLE_QUOTE) > -1) {
+        if (cleanedArgument.contains(DOUBLE_QUOTE)) {
+            if (cleanedArgument.contains(SINGLE_QUOTE)) {
                 throw new IllegalArgumentException(
                         "Can't handle single and double quotes in same argument");
             }
             return buf.append(SINGLE_QUOTE).append(cleanedArgument).append(
                     SINGLE_QUOTE).toString();
-        } else if (cleanedArgument.indexOf(SINGLE_QUOTE) > -1
-                || cleanedArgument.indexOf(" ") > -1) {
+        } else if (cleanedArgument.contains(SINGLE_QUOTE)
+                || cleanedArgument.contains(" ")) {
             return buf.append(DOUBLE_QUOTE).append(cleanedArgument).append(
                     DOUBLE_QUOTE).toString();
         } else {


### PR DESCRIPTION
- single quotation mark don't need escape.
- thread should reset interrupted flag after been interrupted.
- remove two unnecessary `toString()`.
- etc.
I tested all the changes in Win10 and Java7
![image](https://user-images.githubusercontent.com/32363528/106685072-9de60f80-6602-11eb-95b9-63fcd6694681.png)
