### PR TITLE
Automatic-Module-Name manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,9 @@
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <utomatic-Module-Name>${commons.module.name}</utomatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Add a `Automatic-Module-Name: org.apache.commons.exec` manifest entry - similarly as in `commons-lang3` (https://github.com/apache/commons-lang/blob/master/pom.xml#L739) 

This eases creation of modules that depend in commons-exec. Right now the following `module-info.java`:
```
module test.module {
    requires commons.exec;
}
```
results in:
```
module-info.java:2: error: module not found: commons.exec
    requires commons.exec;
                    ^
```
as named Java Modules cannot require unnamed modules.