### PR TITLE
Fix CI only running on Ubuntu & improve OS-specific tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:

--- a/src/test/java/org/apache/commons/exec/AbstractExecTest.java
+++ b/src/test/java/org/apache/commons/exec/AbstractExecTest.java
@@ -24,8 +24,6 @@ public abstract class AbstractExecTest {
     public static final int TEST_TIMEOUT = 15000;
     public static final int WATCHDOG_TIMEOUT = 3000;
 
-    private static final String OS_NAME = System.getProperty("os.name");
-
     private final File testDir = new File("src/test/scripts");
 
     /**
@@ -49,17 +47,4 @@ public abstract class AbstractExecTest {
         }
         return result;
     }
-
-    protected String testIsBrokenForCurrentOperatingSystem() {
-        final String msg = String.format("The test is broken for OS : %s", OS_NAME);
-        System.err.println(msg);
-        return msg;
-    }
-
-    protected String testNotSupportedForCurrentOperatingSystem() {
-        final String msg = String.format("The test is not possible for OS : %s", OS_NAME);
-        System.out.println(msg);
-        return msg;
-    }
-
 }

--- a/src/test/java/org/apache/commons/exec/DefaultExecutorTest.java
+++ b/src/test/java/org/apache/commons/exec/DefaultExecutorTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 /**
@@ -638,26 +639,20 @@ public class DefaultExecutorTest {
      * @throws Exception the test failed
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testExecuteWithRedirectedStreams() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final int exitValue;
-            try (FileInputStream fis = new FileInputStream("./NOTICE.txt")) {
-                final CommandLine cl = new CommandLine(redirectScript);
-                final PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(baos, baos, fis);
-                final DefaultExecutor executor = DefaultExecutor.builder().get();
-                executor.setWorkingDirectory(new File("."));
-                executor.setStreamHandler(pumpStreamHandler);
-                exitValue = executor.execute(cl);
-            }
-            final String result = baos.toString().trim();
-            assertTrue(result.indexOf("Finished reading from stdin") > 0, result);
-            assertFalse(exec.isFailure(exitValue), () -> "exitValue=" + exitValue);
-        } else {
-            if (OS.isFamilyWindows()) {
-                System.err.println("The code samples to do that in windows look like a joke ... :-( .., no way I'm doing that");
-            }
-            System.err.println("The test 'testExecuteWithRedirectedStreams' does not support the following OS : " + System.getProperty("os.name"));
+        final int exitValue;
+        try (FileInputStream fis = new FileInputStream("./NOTICE.txt")) {
+            final CommandLine cl = new CommandLine(redirectScript);
+            final PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(baos, baos, fis);
+            final DefaultExecutor executor = DefaultExecutor.builder().get();
+            executor.setWorkingDirectory(new File("."));
+            executor.setStreamHandler(pumpStreamHandler);
+            exitValue = executor.execute(cl);
         }
+        final String result = baos.toString().trim();
+        assertTrue(result.indexOf("Finished reading from stdin") > 0, result);
+        assertFalse(exec.isFailure(exitValue), () -> "exitValue=" + exitValue);
     }
 
     /**

--- a/src/test/java/org/apache/commons/exec/StandAloneTest.java
+++ b/src/test/java/org/apache/commons/exec/StandAloneTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 /**
@@ -33,44 +34,41 @@ import org.junitpioneer.jupiter.SetSystemProperty;
 public class StandAloneTest {
 
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testDefaultExecutor() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
-            final Executor exec = new DefaultExecutor();
-            exec.setStreamHandler(new PumpStreamHandler());
-            final CommandLine cl = new CommandLine(testScript);
-            exec.execute(cl);
-            assertTrue(new File("./target/mybackup.gz").exists());
-        }
+        final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
+        final Executor exec = new DefaultExecutor();
+        exec.setStreamHandler(new PumpStreamHandler());
+        final CommandLine cl = new CommandLine(testScript);
+        exec.execute(cl);
+        assertTrue(new File("./target/mybackup.gz").exists());
     }
 
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testDefaultExecutorBuilder() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
-            // @formatter:off
-            final Executor exec = DefaultExecutor.builder()
-                    .setThreadFactory(Executors.defaultThreadFactory())
-                    .setExecuteStreamHandler(new PumpStreamHandler())
-                    .setWorkingDirectory(new File("."))
-                    .get();
-            // @formatter:on
-            exec.setStreamHandler(new PumpStreamHandler());
-            final CommandLine cl = new CommandLine(testScript);
-            exec.execute(cl);
-            assertTrue(new File("./target/mybackup.gz").exists());
-        }
+        final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
+        // @formatter:off
+        final Executor exec = DefaultExecutor.builder()
+                .setThreadFactory(Executors.defaultThreadFactory())
+                .setExecuteStreamHandler(new PumpStreamHandler())
+                .setWorkingDirectory(new File("."))
+                .get();
+        // @formatter:on
+        exec.setStreamHandler(new PumpStreamHandler());
+        final CommandLine cl = new CommandLine(testScript);
+        exec.execute(cl);
+        assertTrue(new File("./target/mybackup.gz").exists());
     }
 
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testDefaultExecutorDefaultBuilder() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
-            final Executor exec = DefaultExecutor.builder().get();
-            exec.setStreamHandler(new PumpStreamHandler());
-            final CommandLine cl = new CommandLine(testScript);
-            exec.execute(cl);
-            assertTrue(new File("./target/mybackup.gz").exists());
-        }
+        final File testScript = TestUtil.resolveScriptForOS("./src/test/scripts/standalone");
+        final Executor exec = DefaultExecutor.builder().get();
+        exec.setStreamHandler(new PumpStreamHandler());
+        final CommandLine cl = new CommandLine(testScript);
+        exec.execute(cl);
+        assertTrue(new File("./target/mybackup.gz").exists());
     }
 }

--- a/src/test/java/org/apache/commons/exec/issues/Exec36Test.java
+++ b/src/test/java/org/apache/commons/exec/issues/Exec36Test.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 /**
  * Test EXEC-36 see https://issues.apache.org/jira/browse/EXEC-36
@@ -125,35 +126,30 @@ public class Exec36Test {
      * @throws Exception the test failed
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testExec36_1() throws Exception {
+        CommandLine cmdl;
 
-        if (OS.isFamilyUnix()) {
+        /**
+         * ./script/jrake cruise:publish_installers INSTALLER_VERSION=unstable_2_1 \ INSTALLER_PATH="/var/lib/ cruise-agent/installers"
+         * INSTALLER_DOWNLOAD_SERVER='something' WITHOUT_HELP_DOC=true
+         */
 
-            CommandLine cmdl;
+        final String expected = "./script/jrake\n" + "cruise:publish_installers\n" + "INSTALLER_VERSION=unstable_2_1\n"
+                + "INSTALLER_PATH=\"/var/lib/ cruise-agent/installers\"\n" + "INSTALLER_DOWNLOAD_SERVER='something'\n" + "WITHOUT_HELP_DOC=true";
 
-            /**
-             * ./script/jrake cruise:publish_installers INSTALLER_VERSION=unstable_2_1 \ INSTALLER_PATH="/var/lib/ cruise-agent/installers"
-             * INSTALLER_DOWNLOAD_SERVER='something' WITHOUT_HELP_DOC=true
-             */
+        cmdl = new CommandLine(printArgsScript);
+        cmdl.addArgument("./script/jrake", false);
+        cmdl.addArgument("cruise:publish_installers", false);
+        cmdl.addArgument("INSTALLER_VERSION=unstable_2_1", false);
+        cmdl.addArgument("INSTALLER_PATH=\"/var/lib/ cruise-agent/installers\"", false);
+        cmdl.addArgument("INSTALLER_DOWNLOAD_SERVER='something'", false);
+        cmdl.addArgument("WITHOUT_HELP_DOC=true", false);
 
-            final String expected = "./script/jrake\n" + "cruise:publish_installers\n" + "INSTALLER_VERSION=unstable_2_1\n"
-                    + "INSTALLER_PATH=\"/var/lib/ cruise-agent/installers\"\n" + "INSTALLER_DOWNLOAD_SERVER='something'\n" + "WITHOUT_HELP_DOC=true";
-
-            cmdl = new CommandLine(printArgsScript);
-            cmdl.addArgument("./script/jrake", false);
-            cmdl.addArgument("cruise:publish_installers", false);
-            cmdl.addArgument("INSTALLER_VERSION=unstable_2_1", false);
-            cmdl.addArgument("INSTALLER_PATH=\"/var/lib/ cruise-agent/installers\"", false);
-            cmdl.addArgument("INSTALLER_DOWNLOAD_SERVER='something'", false);
-            cmdl.addArgument("WITHOUT_HELP_DOC=true", false);
-
-            final int exitValue = exec.execute(cmdl);
-            final String result = baos.toString().trim();
-            assertFalse(exec.isFailure(exitValue));
-            assertEquals(expected, result);
-        } else {
-            System.err.println("The test 'testExec36_1' does not support the following OS : " + System.getProperty("os.name"));
-        }
+        final int exitValue = exec.execute(cmdl);
+        final String result = baos.toString().trim();
+        assertFalse(exec.isFailure(exitValue));
+        assertEquals(expected, result);
     }
 
     /**

--- a/src/test/java/org/apache/commons/exec/issues/Exec49Test.java
+++ b/src/test/java/org/apache/commons/exec/issues/Exec49Test.java
@@ -26,9 +26,9 @@ import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecuteResultHandler;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.Executor;
-import org.apache.commons.exec.OS;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 /**
  * Test EXEC-44 (https://issues.apache.org/jira/browse/EXEC-44).
@@ -45,28 +45,27 @@ public class Exec49Test {
      * @throws Exception the test failed
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testExec49_1() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final CommandLine cl = CommandLine.parse("/bin/ls");
-            cl.addArgument("/opt");
-            // redirect stdout/stderr to pipedOutputStream
-            try (PipedOutputStream pipedOutputStream = new PipedOutputStream()) {
-                final PumpStreamHandler psh = new PumpStreamHandler(pipedOutputStream);
-                exec.setStreamHandler(psh);
-                // start an asynchronous process to enable the main thread
-                System.out.println("Preparing to execute process - commandLine=" + cl.toString());
-                final DefaultExecuteResultHandler handler = new DefaultExecuteResultHandler();
-                exec.execute(cl, handler);
-                System.out.println("Process spun off successfully - process=" + cl.getExecutable());
-                try (PipedInputStream pis = new PipedInputStream(pipedOutputStream)) {
-                    while (pis.read() >= 0) {
+        final CommandLine cl = CommandLine.parse("/bin/ls");
+        cl.addArgument("/opt");
+        // redirect stdout/stderr to pipedOutputStream
+        try (PipedOutputStream pipedOutputStream = new PipedOutputStream()) {
+            final PumpStreamHandler psh = new PumpStreamHandler(pipedOutputStream);
+            exec.setStreamHandler(psh);
+            // start an asynchronous process to enable the main thread
+            System.out.println("Preparing to execute process - commandLine=" + cl.toString());
+            final DefaultExecuteResultHandler handler = new DefaultExecuteResultHandler();
+            exec.execute(cl, handler);
+            System.out.println("Process spun off successfully - process=" + cl.getExecutable());
+            try (PipedInputStream pis = new PipedInputStream(pipedOutputStream)) {
+                while (pis.read() >= 0) {
 //                 System.out.println("pis.available() " + pis.available());
 //                 System.out.println("x " + x);
-                    }
                 }
-                handler.waitFor(WAIT);
-                handler.getExitValue(); // will fail if process has not finished
             }
+            handler.waitFor(WAIT);
+            handler.getExitValue(); // will fail if process has not finished
         }
     }
 
@@ -77,28 +76,27 @@ public class Exec49Test {
      * @throws Exception the test failed
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     public void testExec49_2() throws Exception {
-        if (OS.isFamilyUnix()) {
-            final CommandLine cl = CommandLine.parse("/bin/ls");
-            cl.addArgument("/opt");
-            // redirect only stdout to pipedOutputStream
-            try (PipedOutputStream pipedOutputStream = new PipedOutputStream()) {
-                final PumpStreamHandler psh = new PumpStreamHandler(pipedOutputStream, new ByteArrayOutputStream());
-                exec.setStreamHandler(psh);
-                // start an asynchronous process to enable the main thread
-                System.out.println("Preparing to execute process - commandLine=" + cl.toString());
-                final DefaultExecuteResultHandler handler = new DefaultExecuteResultHandler();
-                exec.execute(cl, handler);
-                System.out.println("Process spun off successfully - process=" + cl.getExecutable());
-                try (PipedInputStream pis = new PipedInputStream(pipedOutputStream)) {
-                    while (pis.read() >= 0) {
+        final CommandLine cl = CommandLine.parse("/bin/ls");
+        cl.addArgument("/opt");
+        // redirect only stdout to pipedOutputStream
+        try (PipedOutputStream pipedOutputStream = new PipedOutputStream()) {
+            final PumpStreamHandler psh = new PumpStreamHandler(pipedOutputStream, new ByteArrayOutputStream());
+            exec.setStreamHandler(psh);
+            // start an asynchronous process to enable the main thread
+            System.out.println("Preparing to execute process - commandLine=" + cl.toString());
+            final DefaultExecuteResultHandler handler = new DefaultExecuteResultHandler();
+            exec.execute(cl, handler);
+            System.out.println("Process spun off successfully - process=" + cl.getExecutable());
+            try (PipedInputStream pis = new PipedInputStream(pipedOutputStream)) {
+                while (pis.read() >= 0) {
 //                 System.out.println("pis.available() " + pis.available());
 //                 System.out.println("x " + x);
-                    }
                 }
-                handler.waitFor(WAIT);
-                handler.getExitValue(); // will fail if process has not finished
             }
+            handler.waitFor(WAIT);
+            handler.getExitValue(); // will fail if process has not finished
         }
     }
 

--- a/src/test/java/org/apache/commons/exec/issues/Exec57Test.java
+++ b/src/test/java/org/apache/commons/exec/issues/Exec57Test.java
@@ -23,11 +23,11 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.exec.AbstractExecTest;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.OS;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 /**
  * Test EXEC-57 (https://issues.apache.org/jira/browse/EXEC-57).
@@ -62,14 +62,9 @@ public class Exec57Test extends AbstractExecTest {
      * @throws IOException
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     @Timeout(value = TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void testExecutionOfDetachedProcess() throws IOException {
-
-        if (!OS.isFamilyUnix()) {
-            testNotSupportedForCurrentOperatingSystem();
-            return;
-        }
-
         final CommandLine cmdLine = new CommandLine("sh").addArgument("-c").addArgument("./src/test/scripts/issues/exec-57-detached.sh", false);
         final DefaultExecutor executor = DefaultExecutor.builder().get();
         final PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(System.out, System.err);

--- a/src/test/java/org/apache/commons/exec/issues/Exec62Test.java
+++ b/src/test/java/org/apache/commons/exec/issues/Exec62Test.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteWatchdog;
-import org.apache.commons.exec.OS;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.TestUtil;
 import org.junit.jupiter.api.AfterEach;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 /**
  * @see <a href="https://issues.apache.org/jira/browse/EXEC-62">EXEC-62</a>
@@ -76,10 +76,9 @@ public class Exec62Test {
 
     @Disabled("Test behaves differently between macOS X and Linux - don't know why")
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testMe() throws Exception {
-        if (OS.isFamilyUnix()) {
-            execute("exec-62");
-        }
+        execute("exec-62");
     }
 }

--- a/src/test/java/org/apache/commons/exec/issues/Exec65Test.java
+++ b/src/test/java/org/apache/commons/exec/issues/Exec65Test.java
@@ -30,10 +30,11 @@ import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteWatchdog;
-import org.apache.commons.exec.OS;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
 /**
  * Test to show that watchdog can destroy 'sudo' and 'sleep'.
@@ -48,13 +49,12 @@ public class Exec65Test extends AbstractExecTest {
      * <li>Linux hangs on the process stream while the process is finished</li>
      * <li>Windows seems to have similar problems</li>
      * </ul>
-     *
-     * @TODO Fix tests for Windows & Linux
      */
     @Test
+    // TODO: Fix test for Windows & Linux
+    @EnabledOnOs(value = org.junit.jupiter.api.condition.OS.MAC)
     @Timeout(value = TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void testExec65WithSleepUsingShellScript() throws Exception {
-        assumeTrue(OS.isFamilyMac());
         final DefaultExecutor executor = DefaultExecutor.builder().get();
         executor.setStreamHandler(new PumpStreamHandler(System.out, System.err));
         executor.setWatchdog(new ExecuteWatchdog(WATCHDOG_TIMEOUT));
@@ -85,15 +85,14 @@ public class Exec65Test extends AbstractExecTest {
      * already (thereby requiring a password).
      */
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     @Timeout(value = TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void testExec65WithSudoUsingShellScript() throws Exception {
         assumeFalse(new File(".").getAbsolutePath().contains("travis"),
                 "Test is skipped on travis, because we have to be a sudoer to make the other tests pass.");
         // TODO Fails on GitHub
         assumeTrue(System.getenv("GITHUB_WORKFLOW") == null);
-        if (!OS.isFamilyUnix()) {
-            throw new ExecuteException(testNotSupportedForCurrentOperatingSystem(), 0);
-        }
+
         final DefaultExecutor executor = DefaultExecutor.builder().get();
         executor.setStreamHandler(new PumpStreamHandler(System.out, System.err, System.in));
         executor.setWatchdog(new ExecuteWatchdog(WATCHDOG_TIMEOUT));
@@ -103,12 +102,9 @@ public class Exec65Test extends AbstractExecTest {
     }
 
     @Test
+    @DisabledOnOs(org.junit.jupiter.api.condition.OS.WINDOWS)
     @Timeout(value = TEST_TIMEOUT, unit = TimeUnit.MILLISECONDS)
     public void testExec65WitSleepUsingSleepCommandDirectly() throws Exception {
-
-        if (!OS.isFamilyUnix()) {
-            throw new ExecuteException(testNotSupportedForCurrentOperatingSystem(), 0);
-        }
         final ExecuteWatchdog watchdog = new ExecuteWatchdog(WATCHDOG_TIMEOUT);
         final DefaultExecutor executor = DefaultExecutor.builder().get();
         final CommandLine command = new CommandLine("sleep");


### PR DESCRIPTION
The GitHub workflow file had hardcoded `runs-on: ubuntu-latest`, so even though the title of the builds said something like "build (windows-latest, 21, false)", it was actually always running on Ubuntu.

I have also adjusted the unit tests to use JUnit annotations to disable the tests on certain OS'. Because there is no UNIX constant for `org.junit.jupiter.api.condition.OS`, I changed the logic from only running on UNIX to not running on Windows.
As side note: Previously on Windows unit tests would fail due to tests in `Exec65Test` failing execution by throwing an `ExecuteException`, instead of just skipping execution.

For `org.junit.jupiter.api.condition.OS` I used the fully qualified name to avoid confusion with the `org.apache.commons.exec.OS` class in this project.

At lot of the changes are indentation changes; please configure your Git client / GitHub setting to disable whitespace diff when reviewing the changes.

Feedback is appreciated!